### PR TITLE
Add export default for formkit.config.ts nuxt example

### DIFF
--- a/essentials/installation.md
+++ b/essentials/installation.md
@@ -119,6 +119,8 @@ const config: DefaultConfigOptions = {
   locales: { fr },
   locale: 'fr',
 }
+  
+export default config
 ```
 
 </client-only>


### PR DESCRIPTION
There are missing `export default config` at the end of `formkit.config.ts` of nuxt example to work by just copy-paste.